### PR TITLE
chore: added requirements.txt for installing all dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+asgiref==3.8.1
+Django==5.0.6
+factory-boy==3.3.0
+Faker==25.3.0
+iniconfig==2.0.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.1
+pytest-django==4.8.0
+python-dateutil==2.9.0.post0
+six==1.16.0
+sqlparse==0.5.0


### PR DESCRIPTION
It was required for the instructor the creation of requirements file for installing of all dependencies.

The command used for generating this file was : pip freeze > requirements.txt

Content of the file:
  asgiref==3.8.1
  Django==5.0.6
  factory-boy==3.3.0
  Faker==25.3.0
  iniconfig==2.0.0
  packaging==24.0
  pluggy==1.5.0
  pytest==8.2.1
  pytest-django==4.8.0
  python-dateutil==2.9.0.post0
  six==1.16.0
  sqlparse==0.5.0
